### PR TITLE
Minor improvements for send_ttgo.c

### DIFF
--- a/demos/send_ttgo.c
+++ b/demos/send_ttgo.c
@@ -398,7 +398,7 @@ static void usage(const char *prgname)
 	fprintf(stderr,
 		"%s [options] <capcode> <message>\n"
 		"or:\n"
-		"%s [options] [-l] (from stdin)\n\n"
+		"%s [options] [-l] - (from stdin)\n\n"
 		
 		"Options:\n"
 		"   -d <device>    Serial device (default: %s)\n"
@@ -499,10 +499,14 @@ static void read_params(uint64_t *capcode, char *msg, int argc, char **argv,
 		memcpy(msg, argv[non_opt_start + 1], msg_size + 1);
 		*is_stdin = 0;
 	}
-	else if (argc - non_opt_start == 0) /* Stdin mode */
+	else if (argc - non_opt_start == 1 && strcmp(argv[non_opt_start], "-") == 0) {
+		/* Stdin mode: requires "-" argument */
 		*is_stdin = 1;
-	else
+	}
+	else {
+		/* No arguments or invalid arguments */
 		usage(argv[0]);
+	}
 }
 
 /**

--- a/demos/send_ttgo.c
+++ b/demos/send_ttgo.c
@@ -415,7 +415,7 @@ static void usage(const char *prgname)
 
 		"Normal mode:\n"
 		"   %s 1234567 'MY MESSAGE'\n"
-		"   %s -d /dev/ttyUSB0 -f 915.5 1234567 'MY MESSAGE'",
+		"   %s -d /dev/ttyUSB0 -f 915.5 1234567 'MY MESSAGE'\n",
 		prgname, prgname, DEFAULT_DEVICE, DEFAULT_BAUDRATE,
 		DEFAULT_FREQUENCY, DEFAULT_POWER, prgname, prgname,
 		prgname, prgname);

--- a/demos/send_ttgo.c
+++ b/demos/send_ttgo.c
@@ -29,7 +29,7 @@
 /* Default serial parameters */
 #define DEFAULT_DEVICE    "/dev/ttyACM0"
 #define DEFAULT_BAUDRATE  115200
-#define DEFAULT_FREQUENCY 929.9375
+#define DEFAULT_FREQUENCY 916.0
 #define DEFAULT_POWER     2
 
 static int loop_enabled = 0;


### PR DESCRIPTION
This PR modifies `send_ttgo` by:
1. updating the default frequency to 916 MHz, which falls into ISM range in most jurisdictions and, as such, is usually safe to transmit at
2. fixes a missing line break at the end of the usage message
3. implements the requirement of an explicit argument for stdin mode