### PR TITLE
Add Mail Drop option support

### DIFF
--- a/demos/encode_file.c
+++ b/demos/encode_file.c
@@ -104,7 +104,7 @@ static void usage(const char *prgname)
 
 		"Normal mode:\n"
 		"   %s 1234567 'MY MESSAGE' output.bin\n"
-		"   %s -m 1234567 'MY MESSAGE' output.bin (with mail drop)",
+		"   %s -m 1234567 'MY MESSAGE' output.bin (with mail drop)\n",
 		prgname, prgname, prgname, prgname, prgname, prgname,
 		prgname, prgname);
 	exit(1);

--- a/demos/send_ttgo.c
+++ b/demos/send_ttgo.c
@@ -33,6 +33,7 @@
 #define DEFAULT_POWER     2
 
 static int loop_enabled = 0;
+static int mail_drop_enabled = 0;
 static const char *msg_errors[] = {
 	"Invalid provided error pointer",
 	"Invalid message buffer",
@@ -398,27 +399,30 @@ static void usage(const char *prgname)
 	fprintf(stderr,
 		"%s [options] <capcode> <message>\n"
 		"or:\n"
-		"%s [options] [-l] - (from stdin)\n\n"
+		"%s [options] [-l] [-m] - (from stdin)\n\n"
 		
 		"Options:\n"
 		"   -d <device>    Serial device (default: %s)\n"
 		"   -b <baudrate>  Baudrate (default: %d)\n"
 		"   -f <frequency> Frequency in MHz (default: %f)\n"
-		"   -p <power>     TX power (default: %d, 2-17)\n\n"
+		"   -p <power>     TX power (default: %d, 2-17)\n"
+		"   -l             Loop mode: stays open receiving new lines until EOF\n"
+		"   -m             Mail Drop: sets the Mail Drop Flag in the FLEX message\n\n"
 
 		"Stdin mode:\n"
-		"   -l Loop mode (optional): stays open receiving new lines\n"
-		"                            until EOF\n"
 		"   Example:\n"
 		"     printf '1234567:MY MESSAGE'               | %s\n"
-		"     printf '1234567:MY MSG1\\n1122334:MY MSG2' | %s -l\n\n"
+		"     printf '1234567:MY MSG1\\n1122334:MY MSG2' | %s -l\n"
+		"     printf '1234567:MY MESSAGE'               | %s -m\n"
+		"     printf '1234567:MY MESSAGE'               | %s -l -m\n\n"
 
 		"Normal mode:\n"
 		"   %s 1234567 'MY MESSAGE'\n"
+		"   %s -m 1234567 'MY MESSAGE'\n"
 		"   %s -d /dev/ttyUSB0 -f 915.5 1234567 'MY MESSAGE'\n",
 		prgname, prgname, DEFAULT_DEVICE, DEFAULT_BAUDRATE,
 		DEFAULT_FREQUENCY, DEFAULT_POWER, prgname, prgname,
-		prgname, prgname);
+		prgname, prgname, prgname, prgname, prgname);
 	exit(1);
 }
 
@@ -446,7 +450,7 @@ static void read_params(uint64_t *capcode, char *msg, int argc, char **argv,
 	config->power     = DEFAULT_POWER;
 
 	/* Parse options */
-	while ((opt = getopt(argc, argv, "d:b:f:p:l")) != -1) {
+	while ((opt = getopt(argc, argv, "d:b:f:p:lm")) != -1) {
 		switch (opt) {
 		case 'd':
 			config->device = optarg;
@@ -474,6 +478,9 @@ static void read_params(uint64_t *capcode, char *msg, int argc, char **argv,
 			break;
 		case 'l':
 			loop_enabled = 1;
+			break;
+		case 'm':
+			mail_drop_enabled = 1;
 			break;
 		default:
 			usage(argv[0]);
@@ -618,7 +625,11 @@ int main(int argc, char **argv)
 
 	/* Normal mode */
 	if (!is_stdin) {
-		read_size = tf_encode_flex_message(message, capcode, vec, sizeof vec, &err);
+		struct tf_message_config msg_config = {0};
+		msg_config.mail_drop = mail_drop_enabled;
+		read_size = tf_encode_flex_message_ex(message, capcode, vec,
+			sizeof vec, &err, &msg_config);
+		
 		if (err >= 0) {
 			if (send_flex_via_serial(fd, &config, vec, read_size) < 0)
 				goto error;
@@ -644,7 +655,11 @@ int main(int argc, char **argv)
 			continue;
 		}
 
-		read_size = tf_encode_flex_message(message, capcode, vec, sizeof vec, &err);
+		struct tf_message_config msg_config = {0};
+		msg_config.mail_drop = mail_drop_enabled;
+		read_size = tf_encode_flex_message_ex(message, capcode, vec,
+			sizeof vec, &err, &msg_config);
+		
 		if (err >= 0) {
 			if (send_flex_via_serial(fd, &config, vec, read_size) < 0) {
 				if (!loop_enabled)


### PR DESCRIPTION
This PR:
1. Adds support for the Mail Drop flag on `tinyflex.h`
2. Updates the demo tools accordingly
3. Fixes the issues highlighted in the last PR (#2):
a) Do not exceed 80 cols: a little above is ok (e.g., ~83, 85), 95 is definitelly not ok.
b) Do not mix functions declarations and definitions.
c) Avoid typedefs at any cost.
d) Favor the usage of getopt() in contrast to strcmp+loop
e) Do not leave functions without comments: all functions must have a doxygen-like documentation.
f) Varables declarations must always be at the beginning of the function.