### PR TITLE
adding flex-fsk-tx

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ dedicated Grafana webhook service for seamless alert forwarding.
 A command-line FSK transmitter application that sends FLEX pager messages
 over serial using AT commands.
 Originally based on [tinyflex](https://github.com/Theldus/tinyflex),
-and [ttgo_fsk_tx](https://github.com/rlaneth/ttgo-fsk-tx)
+and [ttgo-fsk-tx](https://github.com/rlaneth/ttgo-fsk-tx)
 adapted for Heltec WiFi Lora32 v3 boards with chip SX1262 LoRa32
 
 [flex-fsk-tx]: https://github.com/geekinsanemx/flex-fsk-tx

--- a/README.md
+++ b/README.md
@@ -194,6 +194,15 @@ dedicated Grafana webhook service for seamless alert forwarding.
 
 [Flex HTTP Server]: https://github.com/geekinsanemx/flex-http-server
 
+### [flex-fsk-tx]
+A command-line FSK transmitter application that sends FLEX pager messages
+over serial using AT commands.
+Originally based on [tinyflex](https://github.com/Theldus/tinyflex),
+and [ttgo_fsk_tx](https://github.com/rlaneth/ttgo-fsk-tx)
+adapted for Heltec WiFi Lora32 v3 boards with chip SX1262 LoRa32
+
+[flex-fsk-tx]: https://github.com/geekinsanemx/flex-fsk-tx
+
 ## Acknowledgements
 This project came from discussions and experiments on paging that I have worked
 on along with [@rlaneth]. He's gifted me a Motorola Advisor Elite pager and a


### PR DESCRIPTION
Hi @Theldus !! hope you're doing great !

I get in love with the ttgo implementation, but I had from some time ago a heltec v3 board laying where I was doing some flex paging attempt for sometime, so I took base of ttgo_fsk_tx and your send_ttgo base code, to do an implementation for Heltec WiFi Lora32 v3 board I would like to share with you guys cc @rlaneth 

I'm just pushing this PR to let you know, but feel free to merge it or not as you consider and also feel free to put or correct the description of the 2ndary project 

@rlaneth I would like to upload the heltec firmware adaptation to your ttgo_fsk_tx repo, but don't know if is only that board approach and also I did it in arduino IDE, don't know if you would like we upload in that way, or do platform.io adaptation

meanwhile I've just put they both together in the flex-fsk-tx as client/server implementation

thank you so much guys!
Regards! :)